### PR TITLE
Sydb/transpile tweaks 01

### DIFF
--- a/Schemas/relaxng.rnc
+++ b/Schemas/relaxng.rnc
@@ -1,0 +1,80 @@
+# RELAX NG XML syntax expressed in RELAX NG Compact syntax.
+
+# Copyright (C) 2003-2004, 2007-2022 Free Software Foundation, Inc.
+
+# This file is part of GNU Emacs.
+
+# GNU Emacs is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# GNU Emacs is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+default namespace rng = "http://relaxng.org/ns/structure/1.0"
+namespace local = ""
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
+
+start = pattern
+
+pattern =
+  element element { (nameQName | nameClass), (common & pattern+) }
+  | element attribute { (nameQName | nameClass), (common & pattern?) }
+  | element group|interleave|choice|optional
+            |zeroOrMore|oneOrMore|list|mixed { common & pattern+ }
+  | element ref|parentRef { nameNCName, common }
+  | element empty|notAllowed|text { common }
+  | element data { type, param*, (common & exceptPattern?) }
+  | element value { commonAttributes, type?, xsd:string }
+  | element externalRef { href, common }
+  | element grammar { common & grammarContent* }
+
+param = element param { commonAttributes, nameNCName, xsd:string }
+
+exceptPattern = element except { common & pattern+ }
+
+grammarContent =
+  definition
+  | element div { common & grammarContent* }
+  | element include { href, (common & includeContent*) }
+
+includeContent =
+  definition
+  | element div { common & includeContent* }
+
+definition =
+  element start { combine?, (common & pattern+) }
+  | element define { nameNCName, combine?, (common & pattern+) }
+
+combine = attribute combine { "choice" | "interleave" }
+
+nameClass =
+  element name { commonAttributes, xsd:QName }
+  | element anyName { common & exceptNameClass? }
+  | element nsName { common & exceptNameClass? }
+  | element choice { common & nameClass+ }
+
+exceptNameClass = element except { common & nameClass+ }
+
+nameQName = attribute name { xsd:QName }
+nameNCName = attribute name { xsd:NCName }
+href = attribute href { xsd:anyURI }
+type = attribute type { xsd:NCName }
+
+common = commonAttributes, foreignElement*
+
+commonAttributes =
+  attribute ns { xsd:string }?,
+  attribute datatypeLibrary { xsd:anyURI }?,
+  foreignAttribute*
+
+foreignElement = element * - rng:* { (anyAttribute | text | anyElement)* }
+foreignAttribute = attribute * - (rng:*|local:*) { text }
+anyElement = element * { (anyAttribute | text | anyElement)* }
+anyAttribute = attribute * { text }

--- a/Tests/resources/in_vitro_ODDS/transpile.odd
+++ b/Tests/resources/in_vitro_ODDS/transpile.odd
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0"
+     xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+      </titleStmt>
+      <publicationStmt>
+        <p>Publication Information</p>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Information about the source</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <schemaSpec ident="schema" start="root">
+        <classSpec ident="class-model" type="model" generate="sequenceOptionalRepeatable"/>
+        <classSpec ident="class-att" type="atts">
+          <classes>
+            <memberOf key="class-model"/>
+          </classes>
+          <attList>
+            <attDef ident="four">
+              <datatype>
+                <dataRef name="int"/>
+              </datatype>
+              <valList type="open">
+                <valItem ident="1"/>
+                <valItem ident="2"/>
+                <valItem ident="3"/>
+              </valList>
+            </attDef>
+          </attList>
+        </classSpec>
+        <dataSpec ident="dataref-vallist">
+          <valList type="closed">
+            <valItem ident="three"/>
+          </valList>
+        </dataSpec>
+        <dataSpec ident="dataref-content-vallist">
+          <content>
+            <valList type="closed">
+              <valItem ident="three"/>
+            </valList>
+          </content>
+        </dataSpec>
+        <elementSpec ident="root">
+          <content>
+            <elementRef key="element-1"/>
+            <elementRef key="element-2"/>
+            <elementRef key="element-3"/>
+            <elementRef key="element-5"/>
+          </content>
+        </elementSpec>
+        <elementSpec ident="element-1">
+          <content>
+            <anyElement/>
+          </content>
+          <attList>
+            <attDef ident="att-datatype-dataref-name-vallist-open">
+              <datatype>
+                <dataRef name="string"/>
+              </datatype>
+              <valList type="open">
+                <valItem ident="one"/>
+                <valItem ident="two"/>
+              </valList>
+            </attDef>
+            <attDef ident="att-nodatatype-vallist-semi">
+              <datatype>
+                <dataRef name="string"/>
+              </datatype>
+              <valList type="semi">
+                <valItem ident="one"/>
+                <valItem ident="two"/>
+              </valList>
+            </attDef>
+            <attDef ident="att-nodatatype-vallist-closed">
+              <valList type="closed">
+                <valItem ident="one"/>
+                <valItem ident="two"/>
+              </valList>
+            </attDef>
+            <attDef ident="att-datatype-name-novallist">
+              <datatype>
+                <dataRef name="int"/>
+              </datatype>
+            </attDef>
+            <attDef ident="att-datatype-dataref-key-vallist">
+              <datatype>
+                <dataRef key="dataref-vallist"/>
+              </datatype>
+            </attDef>
+            <attDef ident="att-datatype-dataref-key-content-vallist">
+              <datatype>
+                <dataRef key="dataref-content-vallist"/>
+              </datatype>
+            </attDef>
+            <attDef ident="att-datatype-dataref-key-content-vallist-vallist">
+              <datatype>
+                <dataRef key="dataref-content-vallist"/>
+              </datatype>
+              <valList type="open">
+                <valItem ident="one"/>
+                <valItem ident="two"/>
+              </valList>
+            </attDef>
+          </attList>
+        </elementSpec>
+        <elementSpec ident="element-2">
+          <classes>
+            <memberOf key="class-att"/>
+          </classes>
+        </elementSpec>
+        <elementSpec ident="element-3">
+          <classes>
+            <memberOf key="class-model"/>
+          </classes>
+        </elementSpec>
+        <elementSpec ident="element-4">
+          <classes>
+            <memberOf key="class-model"/>
+          </classes>
+          <content>
+            <textNode/>
+          </content>
+        </elementSpec>
+        <elementSpec ident="element-5">
+          <content>
+            <classRef key="class-model" expand="sequenceRepeatable"/>
+          </content>
+        </elementSpec>
+      </schemaSpec>
+    </body>
+  </text>
+</TEI>

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -44,7 +44,7 @@
                        xpath-default-namespace="http://www.tei-c.org/ns/1.0">
           <xsl:mode on-no-match="shallow-copy"/>
           <xsl:key name="specItem" match="classSpec | dataSpec | elementSpec | macroSpec" use="@ident"/>
-          <xsl:template match="classRef | dataRef | elementRef | macroRef">
+          <xsl:template match="classRef | dataRef[@key] | elementRef | macroRef">
             <xsl:if test="key('specItem', @key)">
               <xsl:copy>
                 <xsl:apply-templates select="@* | node()"/>

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -44,7 +44,7 @@
                        xpath-default-namespace="http://www.tei-c.org/ns/1.0">
           <xsl:mode on-no-match="shallow-copy"/>
           <xsl:key name="specItem" match="classSpec | dataSpec | elementSpec | macroSpec" use="@ident"/>
-          <xsl:template match="classRef | dataRef[@key] | elementRef | macroRef">
+          <xsl:template match="classRef | dataRef[@key] | elementRef | macroRef | memberOf">
             <xsl:if test="key('specItem', @key)">
               <xsl:copy>
                 <xsl:apply-templates select="@* | node()"/>

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -6,12 +6,59 @@
 
   <p:output port="result" serialization="map{'indent': true()}"/>
 
+  <p:load content-type="application/xml" href="../Tests/resources/in_vitro_ODDS/example.odd"/>
+
+  <p:xslt>
+    <p:documentation>
+      As of 2022-08-17 ODDs that declare attributes from the XML
+      namespace 'http://www.w3.org/XML/1998/namespace' use a colonized
+      name in @ident rather then a non-colonized name and @ns.
+    </p:documentation>
+    <p:with-input port="stylesheet">
+      <p:inline>
+        <xsl:transform version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                       xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+          <xsl:mode on-no-match="shallow-copy"/>
+          <xsl:template match="attDef[starts-with(@ident, 'xml:')][empty(@ns)]">
+            <xsl:copy>
+              <xsl:sequence select="@* except @ident"/>
+              <xsl:attribute name="ident" select="substring-after(@ident, ':')"/>
+              <xsl:attribute name="ns" select="'http://www.w3.org/XML/1998/namespace'"/>
+              <xsl:apply-templates select="node()"/>
+            </xsl:copy>
+          </xsl:template>
+        </xsl:transform>
+      </p:inline>
+    </p:with-input>
+  </p:xslt>
+
+  <p:xslt>
+    <p:documentation>
+      As of 2022-08-17 the odds/odd2odd.xsl of the current ODD
+      processor specification items but does *not* remove references
+      to those items.
+    </p:documentation>
+    <p:with-input port="stylesheet">
+      <p:inline>
+        <xsl:transform version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                       xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+          <xsl:mode on-no-match="shallow-copy"/>
+          <xsl:key name="specItem" match="classSpec | dataSpec | elementSpec | macroSpec" use="@ident"/>
+          <xsl:template match="classRef | dataRef | elementRef | macroRef">
+            <xsl:if test="key('specItem', @key)">
+              <xsl:copy>
+                <xsl:apply-templates select="@* | node()"/>
+              </xsl:copy>
+            </xsl:if>
+          </xsl:template>
+        </xsl:transform>
+      </p:inline>
+    </p:with-input>
+  </p:xslt>
+
   <p:xslt>
     <p:with-input port="stylesheet">
       <p:document content-type="application/xml" href="../XSLT/transpile.xslt"/>
-    </p:with-input>
-    <p:with-input port="source">
-      <p:document content-type="application/xml" href="../Tests/resources/in_vitro_ODDS/transpile.odd"/>
     </p:with-input>
   </p:xslt>
 

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -10,6 +10,21 @@
 
   <p:xslt>
     <p:documentation>
+      As of 2022-08-17 some ODDs contain empty attLists.
+    </p:documentation>
+    <p:with-input port="stylesheet">
+      <p:inline>
+        <xsl:transform version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                       xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+          <xsl:mode on-no-match="shallow-copy"/>
+          <xsl:template match="attList[empty(*)]"/>
+        </xsl:transform>
+      </p:inline>
+    </p:with-input>
+  </p:xslt>
+
+  <p:xslt>
+    <p:documentation>
       As of 2022-08-17 ODDs that declare attributes from the XML
       namespace 'http://www.w3.org/XML/1998/namespace' use a colonized
       name in @ident rather then a non-colonized name and @ns.

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -1,0 +1,22 @@
+<p:declare-step version="3.0" type="atop:transpile"
+                xmlns:atop="http://www.tei-c.org/ns/atop"
+                xmlns:p="http://www.w3.org/ns/xproc">
+
+  <p:documentation>Run the transpiler for the corresponding ODD and validate the result as valid RelaxNG.</p:documentation>
+
+  <p:output port="result" serialization="map{'indent': true()}"/>
+
+  <p:xslt>
+    <p:with-input port="stylesheet">
+      <p:document content-type="application/xml" href="../XSLT/transpile.xslt"/>
+    </p:with-input>
+    <p:with-input port="source">
+      <p:document content-type="application/xml" href="../Tests/resources/in_vitro_ODDS/transpile.odd"/>
+    </p:with-input>
+  </p:xslt>
+
+  <p:validate-with-relax-ng>
+    <p:with-input port="schema" href="../Schemas/relaxng.rnc"/>
+  </p:validate-with-relax-ng>
+
+</p:declare-step>

--- a/Util/transpile.xpl
+++ b/Util/transpile.xpl
@@ -50,8 +50,8 @@
   <p:xslt>
     <p:documentation>
       As of 2022-08-17 the odds/odd2odd.xsl of the current ODD
-      processor specification items but does *not* remove references
-      to those items.
+      processor removes specification items but does *not* remove
+      references to those items.
     </p:documentation>
     <p:with-input port="stylesheet">
       <p:inline>
@@ -77,7 +77,7 @@
     </p:with-input>
   </p:xslt>
 
-  <p:validate-with-relax-ng>
+  <p:validate-with-relax-ng assert-valid="false">
     <p:with-input port="schema" href="../Schemas/relaxng.rnc"/>
   </p:validate-with-relax-ng>
 

--- a/XSLT/modules/content_module.xslt
+++ b/XSLT/modules/content_module.xslt
@@ -21,41 +21,5 @@
                 elements into their RELAX NG output.</xd:p>
         </xd:desc>
     </xd:doc>
-    
-    <xd:doc>
-        <xd:desc>
-            <xd:p>Given element content, an optional minimum, and an optional maximum occurrence, return a corresponding RelaxNG pattern.</xd:p>
-        </xd:desc>
-        <xd:param name="pContent">Element content</xd:param>
-        <xd:param name="pMinOccurrence">Minimum occurrence, defaults to 1.</xd:param>
-        <xd:param name="pMaxOccurrence">Maximum occurrence, defaults to 1.</xd:param>
-        <xd:return>RelaxNG pattern</xd:return>
-    </xd:doc>
-    <xsl:template name="atop:repeat-content" as="element()*">
-        <xsl:param name="pContent" as="element()*"/>
-        <xsl:param name="pMinOccurrence" as="xs:integer?"/>
-        <xsl:param name="pMaxOccurrence" as="xs:string?"/>
-        <xsl:if test="exists($pContent)">
-            <xsl:variable name="vMinOccurrence" as="xs:integer" select="($pMinOccurrence, 1)[1]"/>
-            <xsl:variable name="vMaxOccurrence" as="xs:string" select="($pMaxOccurrence, '1')[1]"/>
-            <xsl:for-each select="1 to $vMinOccurrence">
-                <xsl:sequence select="$pContent"/>
-            </xsl:for-each>
-            <xsl:choose>
-                <xsl:when test="$pMaxOccurrence eq 'unbounded'">
-                    <rng:zeroOrMore>
-                        <xsl:sequence select="$pContent"/>
-                    </rng:zeroOrMore>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:for-each select="($vMinOccurrence + 1) to xs:integer($vMaxOccurrence)">
-                        <rng:optional>
-                            <xsl:sequence select="$pContent"/>
-                        </rng:optional>
-                    </xsl:for-each>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:if>
-    </xsl:template>
 
 </xsl:stylesheet>

--- a/XSLT/modules/functions_module.xslt
+++ b/XSLT/modules/functions_module.xslt
@@ -21,6 +21,7 @@
   <xsl:key name="atop:dataSpec" match="dataSpec" use="@ident"/>
   <xsl:key name="atop:classSpec" match="classSpec" use="@ident"/>
   <xsl:key name="atop:elementSpec" match="elementSpec" use="@ident"/>
+  <xsl:key name="atop:macroSpec" match="macroSpec" use="@ident"/>
   <xsl:key name="atop:classMembers" match="elementSpec[classes/memberOf] | classSpec[classes/memberOf]" use="classes/memberOf/@key"/>
 
   <xd:doc>

--- a/XSLT/modules/functions_module.xslt
+++ b/XSLT/modules/functions_module.xslt
@@ -131,4 +131,40 @@
 
   </xsl:function>
 
+  <xd:doc>
+    <xd:desc>
+      <xd:p>Given element content, an optional minimum, and an optional maximum occurrence, return a corresponding RelaxNG pattern.</xd:p>
+    </xd:desc>
+    <xd:param name="pContent">Element content</xd:param>
+    <xd:param name="pMinOccurrence">Minimum occurrence, defaults to 1.</xd:param>
+    <xd:param name="pMaxOccurrence">Maximum occurrence, defaults to 1.</xd:param>
+    <xd:return>RelaxNG pattern</xd:return>
+  </xd:doc>
+  <xsl:template name="atop:repeat-content" as="element()*">
+    <xsl:param name="pContent" as="element()*"/>
+    <xsl:param name="pMinOccurrence" as="xs:integer?"/>
+    <xsl:param name="pMaxOccurrence" as="xs:string?"/>
+    <xsl:if test="exists($pContent)">
+      <xsl:variable name="vMinOccurrence" as="xs:integer" select="($pMinOccurrence, 1)[1]"/>
+      <xsl:variable name="vMaxOccurrence" as="xs:string" select="($pMaxOccurrence, '1')[1]"/>
+      <xsl:for-each select="1 to $vMinOccurrence">
+        <xsl:sequence select="$pContent"/>
+      </xsl:for-each>
+      <xsl:choose>
+        <xsl:when test="$pMaxOccurrence eq 'unbounded'">
+          <rng:zeroOrMore>
+            <xsl:sequence select="$pContent"/>
+          </rng:zeroOrMore>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="($vMinOccurrence + 1) to xs:integer($vMaxOccurrence)">
+            <rng:optional>
+              <xsl:sequence select="$pContent"/>
+            </rng:optional>
+          </xsl:for-each>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/XSLT/modules/functions_module.xslt
+++ b/XSLT/modules/functions_module.xslt
@@ -131,6 +131,26 @@
 
   </xsl:function>
 
+  <xsl:function name="atop:get-element-pattern-name" as="xs:string">
+    <xsl:param name="pElementSpec" as="element(elementSpec)"/>
+    <xsl:value-of select="concat($pElementSpec/ancestor::schemaSpec[1]/@prefix, $pElementSpec/@prefix, $pElementSpec/@ident)"/>
+  </xsl:function>
+
+  <xsl:function name="atop:get-class-pattern-name" as="xs:string">
+    <xsl:param name="pClassSpec" as="element(classSpec)"/>
+    <xsl:value-of select="concat($pClassSpec/ancestor::schemaSpec[1]/@prefix, $pClassSpec/@prefix, $pClassSpec/@ident)"/>
+  </xsl:function>
+
+  <xsl:function name="atop:get-macro-pattern-name" as="xs:string">
+    <xsl:param name="pMacroSpec" as="element(macroSpec)"/>
+    <xsl:value-of select="concat($pMacroSpec/ancestor::schemaSpec[1]/@prefix, $pMacroSpec/@prefix, $pMacroSpec/@ident)"/>
+  </xsl:function>
+
+  <xsl:function name="atop:get-datatype-pattern-name" as="xs:string">
+    <xsl:param name="pDataSpec" as="element(dataSpec)"/>
+    <xsl:value-of select="concat($pDataSpec/ancestor::schemaSpec[1]/@prefix, $pDataSpec/@prefix, $pDataSpec/@ident)"/>
+  </xsl:function>
+
   <xd:doc>
     <xd:desc>
       <xd:p>Given element content, an optional minimum, and an optional maximum occurrence, return a corresponding RelaxNG pattern.</xd:p>

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -19,10 +19,12 @@
   <xsl:include href="modules/functions_module.xslt"/>
 
   <xsl:template match="schemaSpec" as="element(rng:grammar)">
+    <xsl:variable name="vStartElementSpecs" as="element(elementSpec)+"
+                  select="key('atop:elementSpec', if (@start) then tokenize(@start, '\s+') else 'TEI', .)"/>
     <rng:grammar datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <rng:start>
-        <xsl:for-each select="if (@start) then tokenize(@start, '\s+') else 'TEI'">
-          <rng:ref name="{.}"/>
+        <xsl:for-each select="$vStartElementSpecs">
+          <rng:ref name="{atop:get-element-pattern-name(.)}"/>
         </xsl:for-each>
       </rng:start>
       <xsl:apply-templates mode="atop:anyElement">

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -270,9 +270,11 @@ ignored and the members of the value list are provided.
 
   </xsl:template>
 
-  <!-- anyElement is special. The special mode 'atop:anyElement' creates a
-       recursive RelaxNG pattern. We reference this pattern when
-       processing. -->
+  <xd:doc>
+    <xd:desc>
+      <xd:p>The tei:anyElement content model item is special as it creates a recursive RelaxNG pattern.</xd:p>
+    </xd:desc>
+  </xd:doc>
   <xsl:mode name="atop:anyElement" on-no-match="shallow-skip"/>
 
   <xsl:template match="anyElement" mode="atop:anyElement" as="element(rng:define)">

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -211,7 +211,7 @@ ignored and the members of the value list are provided.
     <rng:text/>
   </xsl:template>
 
-  <xsl:template match="elementRef" as="element(rng:ref)">
+  <xsl:template match="elementRef" as="element()+">
     <xsl:variable name="vElementSpec" as="element(elementSpec)" select="key('atop:elementSpec', @key)"/>
     <xsl:call-template name="atop:repeat-content">
       <xsl:with-param name="pContent" as="element()*">

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -1,0 +1,350 @@
+<xsl:transform version="3.0" expand-text="yes"
+               xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+               xmlns:atop="http://www.tei-c.org/ns/atop"
+               xmlns:rng="http://relaxng.org/ns/structure/1.0"
+               xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xd:doc scope="stylesheet">
+    <xd:desc>
+      <xd:p>Experimental Purified ODD to RelaxNG transpiler</xd:p>
+    </xd:desc>
+  </xd:doc>
+
+  <xsl:mode on-no-match="shallow-skip"/>
+
+  <xsl:output indent="yes"/>
+
+  <xsl:include href="modules/functions_module.xslt"/>
+
+  <xsl:template match="schemaSpec" as="element(rng:grammar)">
+    <rng:grammar datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+      <rng:start>
+        <xsl:for-each select="if (@start) then tokenize(@start, '\s+') else 'TEI'">
+          <rng:ref name="{.}"/>
+        </xsl:for-each>
+      </rng:start>
+      <xsl:apply-templates mode="atop:anyElement">
+        <xsl:with-param name="pDefaultExceptions" as="xs:string*" select="tokenize((@defaultExceptions, 'http://www.tei-c.org/ns/1.0 teix:egXML')[1], '\s+')" tunnel="yes"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates/>
+    </rng:grammar>
+  </xsl:template>
+
+  <xsl:template match="macroSpec" as="element(rng:define)">
+    <rng:define name="{atop:get-macro-pattern-name(.)}">
+      <xsl:apply-templates/>
+    </rng:define>
+  </xsl:template>
+
+  <xsl:template match="dataSpec" as="element(rng:define)">
+    <rng:define name="{atop:get-datatype-pattern-name(.)}">
+      <xsl:apply-templates/>
+    </rng:define>
+  </xsl:template>
+
+  <xsl:template match="classSpec[attList]" as="element(rng:define)">
+    <rng:define name="{atop:get-class-pattern-name(.)}">
+      <xsl:apply-templates/>
+    </rng:define>
+  </xsl:template>
+
+  <!-- An element specification transpiles to a named RelaxNG pattern
+       w/ defining the element. -->
+  <xsl:template match="elementSpec" as="element(rng:define)">
+    <xsl:variable name="vQName" as="xs:QName" select="atop:get-element-qname(.)"/>
+    <xsl:variable name="vContent" as="element()*">
+      <xsl:apply-templates/>
+    </xsl:variable>
+
+    <rng:define name="{atop:get-element-pattern-name(.)}">
+      <rng:element name="{local-name-from-QName($vQName)}"
+                   ns="{namespace-uri-from-QName($vQName)}">
+        <xsl:choose>
+          <xsl:when test="empty($vContent)">
+            <rng:empty/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="$vContent"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </rng:element>
+    </rng:define>
+  </xsl:template>
+
+  <!-- An attribute list transpiles to the sequence or alternate
+       pattern. A fallback template catches unsupported attribute list
+       types. -->
+  <xsl:template match="attList[empty(@org) or @org = 'group']" as="element(rng:group)">
+    <rng:group>
+      <xsl:apply-templates/>
+    </rng:group>
+  </xsl:template>
+
+  <xsl:template match="attList[@org = 'choice']" as="element(rng:choice)">
+    <rng:choice>
+      <xsl:apply-templates/>
+    </rng:choice>
+  </xsl:template>
+
+  <xsl:template match="attList" priority="-10">
+    <xsl:message terminate="yes">
+      <xsl:text>The attribute list type '{@org}' is not supported. This version of only supports the types 'choice' and 'group'.</xsl:text>
+    </xsl:message>
+  </xsl:template>
+
+  <!-- An attribute specifcation transpiles to an (optional) attribute
+       pattern. -->
+  <xsl:template match="attDef[empty(@use) or @use = ('opt', 'rec')]" as="element(rng:optional)">
+    <rng:optional>
+      <xsl:next-match/>
+    </rng:optional>
+  </xsl:template>
+
+  <xsl:template match="attDef" as="element(rng:attribute)">
+    <xsl:variable name="vQName" as="xs:QName" select="atop:get-attribute-qname(.)"/>
+
+    <rng:attribute name="{local-name-from-QName($vQName)}"
+                   ns="{namespace-uri-from-QName($vQName)}">
+
+      <!--
+
+An attribute specification may contain an attribute list (attList) and
+a datatype specification (datatype), one of either, or none.
+
+The current processor works as follows:
+
+If the attDef contains a valList[@type = 'open'], we use the datatype
+specification and list the members of the value list in an annotation.
+
+If the attDef contains a valList[@type = 'semi'], the content model is
+a choice between the datatype and the members of the value list.
+
+If the attDef contains a valList[@type = 'closed'], the datatype is
+ignored and the members of the value list are provided.
+
+      -->
+      <xsl:choose>
+        <xsl:when test="valList[empty(@type) or @type = 'open']">
+          <a:documentation>
+            <xsl:variable name="vSampleValues" as="xs:string*">
+              <xsl:for-each select="valList/valItem">
+                <xsl:text>{position()}] {@ident}</xsl:text>
+              </xsl:for-each>
+            </xsl:variable>
+            <xsl:value-of select="$vSampleValues"/>
+          </a:documentation>
+          <xsl:apply-templates select="datatype"/>
+        </xsl:when>
+        <xsl:when test="valList[@type = ('semi')]">
+          <rng:choice>
+            <xsl:apply-templates/>
+          </rng:choice>
+        </xsl:when>
+        <xsl:when test="valList[@type = ('closed')]">
+          <xsl:apply-templates select="valList"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </rng:attribute>
+  </xsl:template>
+
+  <xsl:template match="datatype" as="element(rng:list)">
+    <xsl:variable name="vDatatypeContent" as="element()+">
+      <xsl:apply-templates/>
+    </xsl:variable>
+
+    <rng:list>
+      <xsl:call-template name="atop:repeat-content">
+        <xsl:with-param name="pContent" as="element()*" select="$vDatatypeContent"/>
+        <xsl:with-param name="pMinOccurrence" as="xs:integer?" select="@minOccurs"/>
+        <xsl:with-param name="pMaxOccurrence" as="xs:string?" select="@maxOccurs"/>
+      </xsl:call-template>
+    </rng:list>
+  </xsl:template>
+
+  <xsl:template match="valList[empty(@type) or @type = 'open']" as="empty-sequence()"/>
+
+  <xsl:template match="valList[@type = ('closed')]" as="element(rng:choice)">
+    <rng:choice>
+      <xsl:apply-templates/>
+    </rng:choice>
+  </xsl:template>
+
+  <xsl:template match="valList[@type = ('semi')]" as="element(rng:value)+">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="valList" priority="-10">
+    <xsl:message terminate="yes">
+      <xsl:text>The value list type '{@type}' is not supported. This version of atop only supports the types 'open', 'semi', and 'closed'.</xsl:text>
+    </xsl:message>
+  </xsl:template>
+
+  <xsl:template match="valItem" as="element(rng:value)">
+    <rng:value>{@ident}</rng:value>
+  </xsl:template>
+
+  <!-- Process members of model.contentPart -->
+  <xsl:template match="alternate" as="element(rng:choice)">
+    <rng:choice>
+      <xsl:apply-templates/>
+    </rng:choice>
+  </xsl:template>
+
+  <xsl:template match="sequence" as="element(rng:group)">
+    <rng:group>
+      <xsl:apply-templates/>
+    </rng:group>
+  </xsl:template>
+
+  <xsl:template match="empty" as="element(rng:empty)">
+    <rng:empty/>
+  </xsl:template>
+
+  <xsl:template match="textNode" as="element(rng:text)">
+    <rng:text/>
+  </xsl:template>
+
+  <xsl:template match="elementRef" as="element(rng:ref)">
+    <xsl:variable name="vElementSpec" as="element(elementSpec)" select="key('atop:elementSpec', @key)"/>
+    <xsl:call-template name="atop:repeat-content">
+      <xsl:with-param name="pContent" as="element()*">
+        <rng:ref name="{atop:get-element-pattern-name($vElementSpec)}"/>
+      </xsl:with-param>
+      <xsl:with-param name="pMinOccurrence" as="xs:integer?" select="@minOccurs"/>
+      <xsl:with-param name="pMaxOccurrence" as="xs:string?" select="@maxOccurs"/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template match="classRef" as="element()+">
+    <xsl:variable name="vClassSpec" as="element(classSpec)" select="key('atop:classSpec', @key, ancestor::schemaSpec)"/>
+    <!-- Create a reference to all class attribute patterns -->
+    <xsl:for-each select="($vClassSpec, key('atop:classMembers', $vClassSpec, ancestor::schemaSpec)[self::classSpec])">
+      <xsl:if test="attList">
+        <rng:ref name="{atop:get-class-pattern-name(.)}"/>
+      </xsl:if>
+    </xsl:for-each>
+
+    <!-- Create reference to class members -->
+    <!-- TODO: Clarify the relationship between classRef/@expand and classSpec/@generate? -->
+    <xsl:variable name="vExpand" as="xs:string" select="(@expand, 'alternation')[1]"/>
+
+    <xsl:element name="{if ($vExpand eq 'alternation') then 'rng:choice' else 'rng:group'}">
+      <xsl:for-each select="atop:get-class-members($vClassSpec, ancestor::schemaSpec)">
+        <xsl:variable name="vReference" as="element()">
+          <xsl:choose>
+            <xsl:when test="$vExpand eq 'sequenceRepeatable'">
+              <rng:oneOrMore>
+                <rng:ref name="{atop:get-element-pattern-name(.)}"/>
+              </rng:oneOrMore>
+            </xsl:when>
+            <xsl:when test="$vExpand eq 'sequenceOptionalRepeatable'">
+              <rng:zeroOrMore>
+                <rng:ref name="{atop:get-element-pattern-name(.)}"/>
+              </rng:zeroOrMore>
+            </xsl:when>
+            <xsl:otherwise>
+              <rng:ref name="{atop:get-element-pattern-name(.)}"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+
+        <xsl:choose>
+          <xsl:when test="$vExpand = ('sequenceOptional', 'sequenceOptionalRepeatable')">
+            <rng:optional>
+              <xsl:sequence select="$vReference"/>
+            </rng:optional>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:sequence select="$vReference"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:element>
+
+  </xsl:template>
+
+  <!-- anyElement is special. The special mode 'atop:anyElement' creates a
+       recursive RelaxNG pattern. We reference this pattern when
+       processing. -->
+  <xsl:mode name="atop:anyElement" on-no-match="shallow-skip"/>
+
+  <xsl:template match="anyElement" mode="atop:anyElement" as="element(rng:define)">
+    <xsl:param name="pDefaultExceptions" as="xs:string*" tunnel="yes"/>
+
+    <xsl:variable name="vPatternName" as="xs:string" select="generate-id()"/>
+    <xsl:variable name="vInScopePrefixes" as="xs:string*" select="in-scope-prefixes(.)"/>
+
+    <rng:define name="{$vPatternName}">
+      <rng:element>
+        <rng:anyName>
+          <xsl:where-populated>
+            <rng:except>
+              <xsl:for-each select="if (@except) then tokenize(@except, '\s+') else $pDefaultExceptions">
+                <!-- Nota bene: teidata.namespaceOrName is ambiguous! -->
+                <xsl:choose>
+                  <xsl:when test="(. castable as xs:Name) and contains(., ':') and (substring-before(., ':') = $vInScopePrefixes)">
+                    <rng:name>{.}</rng:name>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <rng:nsName ns="{.}"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:for-each>
+            </rng:except>
+          </xsl:where-populated>
+        </rng:anyName>
+        <rng:zeroOrMore>
+          <rng:attribute>
+            <rng:anyName/>
+          </rng:attribute>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="{$vPatternName}"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </rng:element>
+    </rng:define>
+
+  </xsl:template>
+
+  <xsl:template match="anyElement" as="element(rng:ref)">
+    <rng:ref name="{generate-id()}"/>
+  </xsl:template>
+
+  <xsl:template match="macroRef" as="element(rng:ref)">
+    <xsl:variable name="vMacroSpec" as="element(macroSpec)" select="key('atop:macroSpec', @key, ancestor::schemaSpec)"/>
+    <rng:ref name="{atop:get-macro-pattern-name($vMacroSpec)}"/>
+  </xsl:template>
+
+  <xsl:template match="dataRef[@name]" as="element(rng:data)">
+    <rng:data type="{@name}">
+      <xsl:if test="@restriction">
+        <rng:param name="pattern">{@restriction}</rng:param>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </rng:data>
+  </xsl:template>
+
+  <xsl:template match="dataFacet" as="element(rng:param)">
+    <rng:param name="{@name}">{@value}</rng:param>
+  </xsl:template>
+
+  <xsl:template match="dataRef[@key]" as="element(rng:ref)">
+    <xsl:variable name="vDataSpec" as="element(dataSpec)" select="key('atop:dataSpec', @key, ancestor::schemaSpec)"/>
+    <rng:ref name="{atop:get-datatype-pattern-name($vDataSpec)}"/>
+  </xsl:template>
+
+  <xsl:template match="dataRef[@ref]" as="empty-sequence()">
+    <xsl:message terminate="yes">
+      <xsl:text>Unsupported datatype specification reference. This version of atop only supports references to XML Schema datatypes (@name) and ODD datatype specifications (@key).</xsl:text>
+    </xsl:message>
+  </xsl:template>
+
+</xsl:transform>

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -223,7 +223,20 @@ ignored and the members of the value list are provided.
   </xsl:template>
 
   <xsl:template match="classRef" as="element()+">
-    <xsl:variable name="vClassSpec" as="element(classSpec)" select="key('atop:classSpec', @key, ancestor::schemaSpec)"/>
+    <xsl:variable name="vClassSpec" as="element(classSpec)*" select="key('atop:classSpec', @key, ancestor::schemaSpec)"/>
+
+    <xsl:if test="empty($vClassSpec)">
+      <xsl:message terminate="yes">
+        <xsl:text>Unable to resolve class reference. There is no class '{@key}' in the current schema {ancestor::schemaSpec/@ident}.</xsl:text>
+      </xsl:message>
+    </xsl:if>
+
+    <xsl:if test="count($vClassSpec) > 1">
+      <xsl:message terminate="yes">
+        <xsl:text>Unable to resolve class reference. There is more then one class '{@key}' in the current schema {ancestor::schemaSpec/@ident}.</xsl:text>
+      </xsl:message>
+    </xsl:if>
+
     <!-- Create a reference to all class attribute patterns -->
     <xsl:for-each select="($vClassSpec, key('atop:classMembers', $vClassSpec, ancestor::schemaSpec)[self::classSpec])">
       <xsl:if test="attList">

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -351,7 +351,7 @@ ignored and the members of the value list are provided.
     <rng:ref name="{atop:get-datatype-pattern-name($vDataSpec)}"/>
   </xsl:template>
 
-  <xsl:template match="dataRef[@ref]" as="empty-sequence()">
+  <xsl:template match="dataRef" priority="-10" as="empty-sequence()">
     <xsl:message terminate="yes">
       <xsl:text>Unsupported datatype specification reference. This version of atop only supports references to XML Schema datatypes (@name) and ODD datatype specifications (@key).</xsl:text>
     </xsl:message>

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -400,9 +400,4 @@ ignored and the members of the value list are provided.
     <xsl:sequence select="."/>
   </xsl:template>
 
-  <xsl:template match="moduleRef[@url]" as="element()+">
-    <rng:externalRef href="{@url}"/>
-    <xsl:apply-templates/>
-  </xsl:template>
-
 </xsl:transform>

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -370,4 +370,8 @@ ignored and the members of the value list are provided.
     </xsl:message>
   </xsl:template>
 
+  <xsl:template match="rng:*" as="element()">
+    <xsl:sequence select="."/>
+  </xsl:template>
+
 </xsl:transform>

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -26,7 +26,7 @@
         </xsl:for-each>
       </rng:start>
       <xsl:apply-templates mode="atop:anyElement">
-        <xsl:with-param name="pDefaultExceptions" as="xs:string*" select="tokenize((@defaultExceptions, 'http://www.tei-c.org/ns/1.0 teix:egXML')[1], '\s+')" tunnel="yes"/>
+        <xsl:with-param name="tpDefaultExceptions" as="xs:string*" select="tokenize((@defaultExceptions, 'http://www.tei-c.org/ns/1.0 teix:egXML')[1], '\s+')" tunnel="yes"/>
       </xsl:apply-templates>
       <xsl:apply-templates/>
     </rng:grammar>
@@ -88,7 +88,7 @@
     </rng:choice>
   </xsl:template>
 
-  <xsl:template match="attList" priority="-10">
+  <xsl:template match="attList" priority="-10" as="empty-sequence()">
     <xsl:message terminate="yes">
       <xsl:text>The attribute list type '{@org}' is not supported. This version of only supports the types 'choice' and 'group'.</xsl:text>
     </xsl:message>
@@ -178,14 +178,16 @@ ignored and the members of the value list are provided.
     <xsl:apply-templates/>
   </xsl:template>
 
-  <xsl:template match="valList" priority="-10">
+  <xsl:template match="valList" priority="-10" as="empty-sequence()">
     <xsl:message terminate="yes">
       <xsl:text>The value list type '{@type}' is not supported. This version of atop only supports the types 'open', 'semi', and 'closed'.</xsl:text>
     </xsl:message>
   </xsl:template>
 
   <xsl:template match="valItem" as="element(rng:value)">
-    <rng:value>{@ident}</rng:value>
+    <rng:value>
+      <xsl:text>{@ident}</xsl:text>
+    </rng:value>
   </xsl:template>
 
   <!-- Process members of model.contentPart -->
@@ -274,7 +276,7 @@ ignored and the members of the value list are provided.
   <xsl:mode name="atop:anyElement" on-no-match="shallow-skip"/>
 
   <xsl:template match="anyElement" mode="atop:anyElement" as="element(rng:define)">
-    <xsl:param name="pDefaultExceptions" as="xs:string*" tunnel="yes"/>
+    <xsl:param name="tpDefaultExceptions" as="xs:string*" tunnel="yes"/>
 
     <xsl:variable name="vPatternName" as="xs:string" select="generate-id()"/>
     <xsl:variable name="vInScopePrefixes" as="xs:string*" select="in-scope-prefixes(.)"/>
@@ -284,11 +286,13 @@ ignored and the members of the value list are provided.
         <rng:anyName>
           <xsl:where-populated>
             <rng:except>
-              <xsl:for-each select="if (@except) then tokenize(@except, '\s+') else $pDefaultExceptions">
+              <xsl:for-each select="if (@except) then tokenize(@except, '\s+') else $tpDefaultExceptions">
                 <!-- Nota bene: teidata.namespaceOrName is ambiguous! -->
                 <xsl:choose>
                   <xsl:when test="(. castable as xs:Name) and contains(., ':') and (substring-before(., ':') = $vInScopePrefixes)">
-                    <rng:name>{.}</rng:name>
+                    <rng:name>
+                      <xsl:text>{.}</xsl:text>
+                    </rng:name>
                   </xsl:when>
                   <xsl:otherwise>
                     <rng:nsName ns="{.}"/>
@@ -326,14 +330,18 @@ ignored and the members of the value list are provided.
   <xsl:template match="dataRef[@name]" as="element(rng:data)">
     <rng:data type="{@name}">
       <xsl:if test="@restriction">
-        <rng:param name="pattern">{@restriction}</rng:param>
+        <rng:param name="pattern">
+          <xsl:text>{@restriction}</xsl:text>
+        </rng:param>
       </xsl:if>
       <xsl:apply-templates/>
     </rng:data>
   </xsl:template>
 
   <xsl:template match="dataFacet" as="element(rng:param)">
-    <rng:param name="{@name}">{@value}</rng:param>
+    <rng:param name="{@name}">
+      <xsl:text>{@value}</xsl:text>
+    </rng:param>
   </xsl:template>
 
   <xsl:template match="dataRef[@key]" as="element(rng:ref)">

--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -400,4 +400,9 @@ ignored and the members of the value list are provided.
     <xsl:sequence select="."/>
   </xsl:template>
 
+  <xsl:template match="moduleRef[@url]" as="element()+">
+    <rng:externalRef href="{@url}"/>
+    <xsl:apply-templates/>
+  </xsl:template>
+
 </xsl:transform>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,9 @@
 <project>
+
+  <taskdef name="jing" classname="com.thaiopensource.relaxng.util.JingTask">
+    <classpath location="Lib/jing.jar"/>
+  </taskdef>
+
   <fileset id="xspec-files" dir="Tests/xspec" includes="*.xspec"/>
 
   <target name="test.xspec" description="Run all XSpec tests">
@@ -7,6 +12,17 @@
       <param name="files" expression="${xspec.files}"/>
     </xslt>
     <subant antfile="xspec-runner.xml" buildpath="Tests" target="xspec-runner"/>
+  </target>
+
+  <target name="transpile" description="Run the experimental transpiler">
+    <tempfile destDir="${java.io.tmpdir}" suffix=".rng" property="transpile.odd.rng"/>
+    <xslt style="XSLT/transpile.xslt" in="Tests/resources/in_vitro_ODDS/transpile.odd"
+          out="${transpile.odd.rng}">
+      <classpath location="lib/saxon-he-11.jar"/>
+    </xslt>
+    <jing rngfile="Schemas/relaxng.rnc" compactsyntax="true">
+      <fileset file="${transpile.odd.rng}"/>
+    </jing>
   </target>
 
 </project>


### PR DESCRIPTION
 * Major: Use a pattern prefix on RELAX NG patterns (and references to them).
 * Add a colophonic comment block at the top with some metadata.
 * Minor: Use atomic comparison operators when neither L nor R is a sequence.
 * Minor: Do not bother with 2nd argument to tokenize().
 * Minor: Remove some tests for error conditions that should be caught before this point in processing (by the PLODD schema).
 * Minor: Changes to comments and documentation.