### PR TITLE
direct copy of namespace nodes; etc.

### DIFF
--- a/XSLT/transpile.xslt
+++ b/XSLT/transpile.xslt
@@ -55,7 +55,7 @@
 	  NG the namespace specified by the prefix of a QName in the
 	  @name attribute takes precedence over the @ns attribute.
       -->
-      <xsl:copy-of select="namespace-node()"/>
+      <xsl:sequence select="namespace-node()"/>
 
       <!--
 	  Start with an alternation of the @start elements. Note that


### PR DESCRIPTION
The only big change is to use `<xsl:copy>` to copy over namespace nodes, rather than use a combination of `in-scope-prefixes()` and `namespace-uri-for-prefix()`.