### PR TITLE
Issue 34 validation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,33 +38,10 @@
       TARGET preValidatePloddWithSch
       This target validates the incoming unprocessed PLODD file with a local Schematron schema.
     </description>
-    <dirname property="ploddDir" file="${inputPlodd}"/>
-    <antcall target="compileSchematron">
+    <antcall target="validateWithSchematron">
+      <param name="xmlFile" value="${inputPlodd}"/>
       <param name="schSchemaFile" value="${basedir}/Schemas/pre-transpile.sch"/>
     </antcall>
-    <echo message="Validate ${ploddDir}/${ploddName}.plodd with pre-transpile.sch."/>
-    <echo message="Process ${ploddDir}/${ploddName}.plodd with compiles pre-transpile_sch.xslt."/>
-    <!-- Generate the SVRL needed. -->
-    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
-      <arg value="-xsl:${basedir}/Schemas/pre-transpile_sch.xslt"/>
-      <arg value="-s:${ploddDir}/${ploddName}.plodd"/>
-      <arg value="-o:${ploddDir}/${ploddName}.svrl"/>
-    </java>
-    <!-- Process with SVRL parser. -->
-    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
-      <arg value="-xsl:${basedir}/XSLT/svrl2msgs.xslt"/>
-      <arg value="-s:${ploddDir}/${ploddName}.svrl"/>
-      <arg value="-o:${ploddDir}/${ploddName}_svrl.txt"/>
-    </java>
-    <!-- Read the output to see if there's anything there. Make it quiet so
-         there's no error message when the file is empty. -->
-    <loadfile property="svrlMessages" srcFile="${ploddDir}/${ploddName}_svrl.txt" quiet="true"/>
-    <!-- Fail if there's anything in the file other than a linebreak. -->
-    <fail message="${ploddDir}/${ploddName}.plodd: ${svrlMessages}">
-      <condition>
-        <length length="2" string="${svrlMessages}" when="gt"/>
-      </condition>
-    </fail>
   </target>
   
   <target name="preValidatePloddWithRng" description="Validate the incoming PLODD with RELAXNG.">
@@ -153,32 +130,10 @@
       This target validates an extracted Schematron file with a local Schematron schema.
     </description>
     <dirname property="ploddDir" file="${inputPlodd}"/>
-    <antcall target="compileSchematron">
+    <antcall target="validateWithSchematron">
+      <param name="xmlFile" value="${ploddDir}/${ploddName}.sch"/>
       <param name="schSchemaFile" value="${basedir}/Schemas/schematron.sch"/>
     </antcall>
-    <echo message="Validate ${ploddDir}/${ploddName}.sch with schematron.sch."/>
-    <echo message="Process ${ploddDir}/${ploddName}.sch with compiled schematron_sch.xslt."/>
-    <!-- Generate the SVRL needed. -->
-    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
-      <arg value="-xsl:${basedir}/Schemas/schematron_sch.xslt"/>
-      <arg value="-s:${ploddDir}/${ploddName}.sch"/>
-      <arg value="-o:${ploddDir}/${ploddName}_sch.svrl"/>
-    </java>
-    <!-- Process with SVRL parser. -->
-    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
-      <arg value="-xsl:${basedir}/XSLT/svrl2msgs.xslt"/>
-      <arg value="-s:${ploddDir}/${ploddName}_sch.svrl"/>
-      <arg value="-o:${ploddDir}/${ploddName}_sch_svrl.txt"/>
-    </java>
-    <!-- Read the output to see if there's anything there. Make it quiet so
-         there's no error message when the file is empty. -->
-    <loadfile property="svrlMessages" srcFile="${ploddDir}/${ploddName}_sch_svrl.txt" quiet="true"/>
-    <!-- Fail if there's anything in the file other than a linebreak. -->
-    <fail message="${ploddDir}/${ploddName}.sch: ${svrlMessages}">
-      <condition>
-        <length length="2" string="${svrlMessages}" when="gt"/>
-      </condition>
-    </fail>
   </target>
   
   <target name="transpilePlodd" description="Run the full sequence of steps to create RNG and Schematron from a PLODD file.">

--- a/build.xml
+++ b/build.xml
@@ -9,27 +9,14 @@
   <!-- Globals file which defines various properties and also imports build.properties. -->
   <import file="buildGlobals.xml"/>
   
+  <!-- Validation file which provides generic validation targets. -->
+  <import file="buildValidate.xml"/>
+  
   <basename property="ploddName" file="${inputPlodd}" suffix=".plodd"/>
   
   <!-- Any single Schematron file we want to compile and use. -->
   <property name="schSchemaFile" value=""/>
   
-  <target name="compileSchematron">
-    <description>
-      TARGET compileSchematron
-      This uses the schxslt XSLT to compile a Schematron file
-      into XSLT which can then be used for validation.
-    </description>
-    <echo message="Compiling ${schSchemaFile} into XSLT..."/>
-    <!-- Properties derived from the Schematron input file. -->
-    <basename property="schSchemaName" file="${schSchemaFile}" suffix=".sch"/>
-    <dirname property="schSchemaDir" file="${schSchemaFile}"/>
-    <java jar="${saxon}" fork="true" failonerror="true">
-      <arg line="-s:${schSchemaFile}"/>
-      <arg line="-o:${schSchemaDir}/${schSchemaName}_sch.xslt"/>
-      <arg line="-xsl:'${schxsltCompiler}'"/>
-    </java>
-  </target>
 
   <target name="transpile" description="Run the experimental transpiler through Morgana">
     <dirname property="ploddDir" file="${inputPlodd}"/>
@@ -107,7 +94,6 @@
     <jing rngfile="${basedir}/Schemas/ploddSchemaSpecification.rng" failonerror="true">
       <fileset file="${ploddDir}/${ploddName}.plodd"/>
     </jing>
-    
   </target>
   
   <target name="preprocessPlodd" description="Do some minor preprocessing on the PLODD file before the transpile stage.">

--- a/build.xml
+++ b/build.xml
@@ -17,23 +17,6 @@
   <!-- Any single Schematron file we want to compile and use. -->
   <property name="schSchemaFile" value=""/>
   
-
-  <target name="transpile" description="Run the experimental transpiler through Morgana">
-    <dirname property="ploddDir" file="${inputPlodd}"/>
-    <echo message="Processing ${inputPlodd} to ${ploddDir}/${ploddName}.rng"/>
-    <java failonerror="true" fork="true" classname="com.xml_project.morganaxproc3.XProcEngine" dir="${basedir}">
-      <classpath>
-        <pathelement location="${basedir}/Lib/morgana/MorganaXProc-IIIse.jar"/>
-        <pathelement location="${basedir}/Lib/morgana/MorganaXProc-IIIse_lib/*" />
-      </classpath>
-      <arg value="-config=${basedir}/Lib/morgana/config.xml"/>
-      <arg value="${basedir}/Util/pipeline.xpl"/>
-      <arg value="-option:teiOddSpecification=${inputPlodd}"/>
-      <arg value="-output:result=${ploddDir}/${ploddName}.rng"/>
-      <arg value="-output:schematron=${ploddDir}/${ploddName}.sch"/>
-    </java>
-  </target>
-  
   <target name="preclean" description="Clean out the results of any previous runs">
     <description>
       TARGET preClean

--- a/buildTest.xml
+++ b/buildTest.xml
@@ -118,7 +118,6 @@
         </exec>
       </then>
     </if>
-    
     <jing rngfile="${basedir}/Schemas/ploddSchemaSpecification.rng">
       <fileset dir="${basedir}/tmp/PLODDs" includes="*.odd"/>
     </jing>
@@ -194,10 +193,6 @@
       global="true"/>
     <echo>Schema is: ${testSchema}...</echo>
     <jing rngfile="${testSchema}" file="${inFile}"/>
-    <!--<java jar="${basedir}/Lib/jing.jar" fork="yes" failonerror="true">
-      <arg value="${testSchema}" />
-      <arg line="${inFile}" />
-    </java>-->
   </target>
   
   <target name="checkInvalidInstances">

--- a/buildValidate.xml
+++ b/buildValidate.xml
@@ -1,0 +1,28 @@
+<project basedir=".">
+  <description>
+    This Ant build file provides generic validation targets to be called from 
+    other targets.
+  </description>
+  
+  <import file="buildGlobals.xml"/>
+  
+  <target name="temp">
+    <!--<antcall target="validateWithRng">
+      <param name="rngFile" value="${basedir}/Schemas/ploddSchemaSpecification.rng"/>
+      <param name="xmlFile" value="${basedir}/Tests/transpile_test_suite/altIdents_and_nss/altIdents_and_nss.plodd"/>
+    </antcall>-->
+  </target>
+  
+  <target name="validateWithRng" description="Validate an XML file with a RELAXNG schema.">
+    <description>
+      TARGET validateWithRng
+      This target an XML file with an RNG file. Both are passed in as parameters.
+    </description>
+    <!--<param name="xmlFile"/>
+    <param name="rngFile"/>-->
+    <echo message="Validating ${xmlFile} with ${rngFile}"/>
+    <jing rngfile="${rngFile}" failonerror="true">
+      <fileset file="${xmlFile}"/>
+    </jing>
+  </target>
+</project>

--- a/buildValidate.xml
+++ b/buildValidate.xml
@@ -22,8 +22,6 @@
       TARGET validateWithRng
       This target an XML file with an RNG file. Both are passed in as parameters.
     </description>
-    <!--<param name="xmlFile"/>
-    <param name="rngFile"/>-->
     <echo message="Validating ${xmlFile} with ${rngFile}"/>
     <jing rngfile="${rngFile}" failonerror="true">
       <fileset file="${xmlFile}"/>

--- a/buildValidate.xml
+++ b/buildValidate.xml
@@ -11,6 +11,10 @@
       <param name="rngFile" value="${basedir}/Schemas/ploddSchemaSpecification.rng"/>
       <param name="xmlFile" value="${basedir}/Tests/transpile_test_suite/altIdents_and_nss/altIdents_and_nss.plodd"/>
     </antcall>-->
+    <antcall target="validateWithSchematron">
+      <param name="schSchemaFile" value="${basedir}/Schemas/pre-transpile.sch"/>
+      <param name="xmlFile" value="${basedir}/Tests/transpile_test_suite/altIdents_and_nss/altIdents_and_nss.plodd"/>
+    </antcall>
   </target>
   
   <target name="validateWithRng" description="Validate an XML file with a RELAXNG schema.">
@@ -25,4 +29,61 @@
       <fileset file="${xmlFile}"/>
     </jing>
   </target>
+  
+  <target name="compileSchematron">
+    <description>
+      TARGET compileSchematron
+      This uses the schxslt XSLT to compile a Schematron file
+      into XSLT which can then be used for validation.
+    </description>
+    <echo message="Compiling ${schSchemaFile} into XSLT..."/>
+    <!-- Properties derived from the Schematron input file. -->
+    <basename property="schSchemaName" file="${schSchemaFile}" suffix=".sch"/>
+    <dirname property="schSchemaDir" file="${schSchemaFile}"/>
+    <java jar="${saxon}" fork="true" failonerror="true">
+      <arg line="-s:${schSchemaFile}"/>
+      <arg line="-o:${schSchemaDir}/${schSchemaName}_sch.xslt"/>
+      <arg line="-xsl:'${schxsltCompiler}'"/>
+    </java>
+  </target>
+  
+  <target name="validateWithSchematron" description="Validate an XML file with a Schematron file.">
+    <description>
+      TARGET validateWithSchematron
+      This target validates an XML file with a Schematron schema, and fails if it is invalid.
+      Parameters xmlFile and SchematronFile are passed in as parameters.
+    </description>
+    <echo message="Validate ${xmlFile} with ${schSchemaFile}."/>
+    <basename property="schSchemaName" file="${schSchemaFile}" suffix=".sch"/>
+    <dirname property="schSchemaDir" file="${schSchemaFile}"/>
+    <basename property="xmlFileName" file="${xmlFile}"/>
+    <dirname property="xmlFileDir" file="${xmlFile}"/>
+    <dirname property="xmlFileDir" file="${xmlFile}"/>
+    <antcall target="compileSchematron">
+      <param name="schSchemaFile" value="${schSchemaFile}"/>
+    </antcall>
+    <echo message="Process ${xmlFile} with compiled ${schSchemaDir}/${schSchemaName}_sch.xslt."/>
+    <!-- Generate the SVRL needed. -->
+    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
+      <arg value="-xsl:${schSchemaDir}/${schSchemaName}_sch.xslt"/>
+      <arg value="-s:${xmlFile}"/>
+      <arg value="-o:${xmlFileDir}/${xmlFileName}.svrl"/>
+    </java>
+    <!-- Process with SVRL parser. -->
+    <java failonerror="true" fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" dir="${basedir}">
+      <arg value="-xsl:${basedir}/XSLT/svrl2msgs.xslt"/>
+      <arg value="-s:${xmlFileDir}/${xmlFileName}.svrl"/>
+      <arg value="-o:${xmlFileDir}/${xmlFileName}_svrl.txt"/>
+    </java>
+    <!-- Read the output to see if there's anything there. Make it quiet so
+         there's no error message when the file is empty. -->
+    <loadfile property="svrlMessages" srcFile="${xmlFileDir}/${xmlFileName}_svrl.txt" quiet="true"/>
+    <!-- Fail if there's anything in the file other than a linebreak. -->
+    <fail message="${xmlFileDir}/${xmlFileName}.plodd: ${svrlMessages}">
+      <condition>
+        <length length="2" string="${svrlMessages}" when="gt"/>
+      </condition>
+    </fail>
+  </target>
+  
 </project>


### PR DESCRIPTION
I've created generic validation targets in a new file buildValidate.xml, and refactored existing code to call those targets where appropriate, in place of the repetition we had before. With RNG validation, though, invoking jing in simple cases is a one-liner, so I haven't bothered to replace all those invocations with a call to the generic target, since that would add overhead. However, if we decide that we always want to do RNG validation in a particular way and ensure that's universal, we can revisit that. The main benefit is that Schematron validation is now a single call with two parameters.