### PR TITLE
make calls to XSLT consistent

### DIFF
--- a/buildTest.xml
+++ b/buildTest.xml
@@ -101,9 +101,14 @@
     <echo message="Pruning ${inFile}..."/>
     <basename file="${inFile}" property="plainFileName" suffix=".derodd"/>
     <property name="outFile" value="${basedir}/tmp/PLODDs/${plainFileName}.odd"/>
-    <xslt style="${basedir}/XSLT/prune_compiled_to_PLODD.xslt" in="${inFile}" out="${outFile}">
-      <classpath location="${saxon}"/>
-    </xslt>
+    <java fork="true" classname="net.sf.saxon.Transform" classpath="${saxon}" failonerror="true">
+      <jvmarg value="-Xmx1024m"/>
+      <arg value="-s:${inFile}"/>
+      <arg value="-xsl:${basedir}/XSLT/prune_compiled_to_PLODD.xslt"/>
+      <arg value="-o:${outFile}"/>
+      <arg value="-xi"/>
+      <arg value="--suppressXsltNamespaceCheck:on"/>
+    </java>
   </target>
   
   <target name="validateResults">


### PR DESCRIPTION
Change lone call to Ant’s XSLT task to use a Java task instead, mostly for consistency.